### PR TITLE
added: visual feedback for sending edited variation

### DIFF
--- a/front-end/src/contexts/ProjectContext.jsx
+++ b/front-end/src/contexts/ProjectContext.jsx
@@ -252,9 +252,12 @@ export const ProjectProvider = ({ children }) => {
         }
       );
       return { success: true, data: response.data };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.message || err.message || "Failed to send the variation for approval";
+   } catch (err) {
+    const status = err.response?.status;
+    const backendMsg = err.response?.data?.message || err.message;
+    // provides visual feedback for 
+      const errorMessage = status === 400 ? "Updated variation has been sent" : backendMsg || "Failed to send the variation for approval";
+        // err.response?.data?.message || err.message || 
       setError(errorMessage);
       return { success: false, error: errorMessage };
     } finally {


### PR DESCRIPTION
When we try to send a variation for signature if we do it on a variation with the status *submitted* we get the appropriate feedback. **We might want to change the colour of the banner. Red is the error colour, but we don't have one here. Yellow?**
<img width="781" height="1044" alt="image" src="https://github.com/user-attachments/assets/0351aca7-ecda-4882-9fba-b74e3232bcf3" />

**Used to be**
<img width="1452" height="398" alt="image" src="https://github.com/user-attachments/assets/3667f8b2-f380-4443-ab2d-570a0fa24483" />

**Now**
<img width="808" height="576" alt="image" src="https://github.com/user-attachments/assets/7a807c45-682c-43f3-a6b7-a93019bd9d49" />
